### PR TITLE
Use subcommands for lock,release,check

### DIFF
--- a/framework/main.py
+++ b/framework/main.py
@@ -10,77 +10,122 @@ from rlockertools.resourcelocker import ResourceLocker
 import sys
 
 
-def init_argparser():
+def init_argparser(args=None):
     """
     Initialization  of argument parse library with it's arguments
     Args:
-        None
+        args: list of args to parse in `sys.argv` form. Useful for testing
+            passed to `ArgumentParser.parse_args` . default to None (use `sys.argv`)
 
     Returns:
         object: Parsed arguments - returned from parser.parse_args()
     """
+    server_args_parser = ArgumentParser(add_help=False)
 
-    parser = ArgumentParser()
-    parser.add_argument(
+    # sharing arguments using parent parsers.
+    # https://stackoverflow.com/a/56595689 and https://stackoverflow.com/a/7498853
+
+    # TODO These really should be config file things,
+    server_args_parser.add_argument(
+        "-s",
         "--server-url",
         help="The URL of the Resource Locker Server",
         required=True,
         action="store",
     )
-    parser.add_argument(
+    server_args_parser.add_argument(
+        "-t",
         "--token",
         help="Token of the user that creates API calls",
         required=True,
         action="store",
     )
-    parser.add_argument(
-        "--release", help="Use this argument to release a resource", action="store_true"
+    server_args_parser.add_argument(
+        "--resume-on-connection-error",
+        help="Use this argument in case you don't want to break queue execution"
+        " in the middle of waiting for queue status being FINISHED",
+        action="store_true",
     )
-    parser.add_argument(
-        "--lock", help="Use this argument to lock a resource", action="store_true"
-    )
-    parser.add_argument(
-        "--check", help="Use this to check if a resource is available", action="store_true"
-    )
-    parser.add_argument(
-        "--resume-on-connection-error", help="Use this argument in case you don't want to break queue execution"
-                                             " in the middle of waiting for queue status being FINISHED", action="store_true"
-    )
-    parser.add_argument(
-        "--signoff",
-        help="Use this when lock=True, locking a resource requires signoff",
-        action="store",
-    )
-    parser.add_argument(
-        "--priority",
-        help="Use this when lock=True, specify the level of priority the resource should be locked",
-        action="store",
-    )
-    parser.add_argument(
-        "--search-string",
-        help="Use this when lock=True or check=True, specify the label or the name of the lockable resource",
-        action="store",
-    )
-    parser.add_argument(
-        "--link",
-        help="Use this when lock=True, specify the link of the CI/CD pipeline that locks the resource",
-        action="store",
-    )
-    parser.add_argument(
+
+    # TODO Come up with a better way of handling defaults in ResourceLocker
+    # Doing interval here since it is required as part of `--resume-on-connection-error`
+    interval_default = 15
+    server_args_parser.add_argument(
+        "-i",
         "--interval",
-        help="Use this when lock=True, how many seconds to wait between each call"
-        " while checking for a free resource",
+        help=f"How many seconds to wait between each call (default {interval_default})",
         type=int,
         action="store",
+        default=interval_default,
     )
-    parser.add_argument(
+
+    parser = ArgumentParser(parents=[server_args_parser])
+
+    # Parent of all sub commands that take a search string
+    search_parser = ArgumentParser(add_help=False)
+    search_parser.add_argument(
+        "search_string",
+        metavar="SEARCH",
+        help="Specify the label or the name of the lockable resource",
+    )
+
+    # Parent of all sub commands that take a signoff string
+    signoff_parser = ArgumentParser(add_help=False)
+    signoff_parser.add_argument(
+        "signoff",
+        metavar="SIGN_OFF",
+        help="locking or releasing a resource requires signoff",
+    )
+
+    # subcommands
+    subparsers = parser.add_subparsers(dest="action")
+
+    # release
+    release_parser = subparsers.add_parser(
+        "release",
+        # parents=[server_args_parser, signoff_parser],
+        parents=[signoff_parser],
+        help="Release a resource",
+    )
+
+    # check
+    check_parser = subparsers.add_parser(
+        "check",
+        # parents = [server_args_parser, search_parser],
+        parents=[search_parser],
+        help="check a resource",
+    )
+
+    # lock
+    lock_parser = subparsers.add_parser(
+        "lock",
+        parents=[search_parser, signoff_parser],
+        help="Lock a resource",
+    )
+    lock_parser.add_argument(
+        "priority",
+        help="Specify the level of priority the resource should be locked",
+        metavar="PRIORITY",
+    )
+    # TODO Come up with a better way of handling defaults in ResourceLocker class
+    attempts_default = 120
+    lock_parser.add_argument(
+        "-a",
         "--attempts",
-        help="Use this when lock=True, how many times to create an API call"
-        " that will check for a free resource ",
+        help="How many times to create an API call"
+        f" that will check for a free resource (default {attempts_default})",
         type=int,
         action="store",
+        default=attempts_default,
     )
-    return parser.parse_args()
+    lock_parser.add_argument(
+        "-l",
+        "--link",
+        help="Specify the link of the CI/CD pipeline that locks the resource",
+        action="store",
+    )
+
+    return parser.parse_args(args=args)
 
 
 def run(args):
@@ -96,7 +141,7 @@ def run(args):
     try:
         # Instantiate the connection vs Resource locker:
         inst = ResourceLocker(instance_url=args.server_url, token=args.token)
-        if args.release:
+        if args.action == "release":
             resource_to_release = inst.get_lockable_resources(signoff=args.signoff)
             if resource_to_release:
                 release_attempt = inst.release(resource_to_release[0])
@@ -104,7 +149,7 @@ def run(args):
             else:
                 print(f"There is no resource: {args.signoff} locked, ignoring!")
 
-        if args.lock:
+        elif args.action == "lock":
             new_queue = inst.find_resource(
                 search_string=args.search_string,
                 signoff=args.signoff,
@@ -146,7 +191,7 @@ def run(args):
                 # We print json response, it is better to visualize it nicer:
                 pp.pprint(verify_lock)
 
-        if args.check:
+        elif args.action == "check":
             resources_by_name = inst.get_lockable_resources(name=args.search_string)
             resources_by_label = inst.get_lockable_resources(label_matches=args.search_string)
             if (resources_by_name or resources_by_label):
@@ -174,6 +219,7 @@ def run(args):
     except Exception as e:
         print("An unexpected error occured!")
         raise
+
 
 def main():
     os.environ["PYTHONUNBUFFERED"] = "1"


### PR DESCRIPTION
Part of #19

made use of [argparse.subparser](https://docs.python.org/3/library/argparse.html#sub-commands) to implement subcommands. Also various related changed detailed below. 


So locking a resource `aws-resource-1` with signoff `ptest1` and priortity `3` now looks like this :
```
rlock  -s <url> -t <token> lock aws-resource-1 ptest1 3
```
my hope is in the future we can get rid of requiring `-s` and `-t` with some sort of config file. 

### Details
Arguments that are required by certain things (signoff, search string, etc) are now positional args
This makes it easy to determine if they've been specified and error out if not. Eliminating common
user issues. Server args `--server-url` form, but that should change if we start using a config file or something.

Added defaults for `--interval` and `--attempts` based on the ones in `ResourceLocker` class

Added short form for most common params (`-s`, `-t`, etc)

Here is what `--help` looks like:

```
$ rlock --help
usage: rlock [-h] -s SERVER_URL -t TOKEN [--resume-on-connection-error] [-i INTERVAL] {release,check,lock} ...

positional arguments:
  {release,check,lock}
    release             Release a resource
    check               check a resource
    lock                Lock a resource

options:
  -h, --help            show this help message and exit
  -s SERVER_URL, --server-url SERVER_URL
                        The URL of the Resource Locker Server
  -t TOKEN, --token TOKEN
                        Token of the user that creates API calls
  --resume-on-connection-error
                        Use this argument in case you don't want to break queue execution in the middle of waiting for queue status being FINISHED
  -i INTERVAL, --interval INTERVAL
                        How many seconds to wait between each call (default 15)

```

```
$ rlock lock --help
usage: rlock lock [-h] [-a ATTEMPTS] [-l LINK] SEARCH SIGN_OFF PRIORITY

positional arguments:
  SEARCH                Specify the label or the name of the lockable resource
  SIGN_OFF              locking or releasing a resource requires signoff
  PRIORITY              Specify the level of priority the resource should be locked

options:
  -h, --help            show this help message and exit
  -a ATTEMPTS, --attempts ATTEMPTS
                        How many times to create an API call that will check for a free resource (default 120)
  -l LINK, --link LINK  Specify the link of the CI/CD pipeline that locks the resource
```

```
$ rlock check --help
usage: rlock check [-h] SEARCH

positional arguments:
  SEARCH      Specify the label or the name of the lockable resource

options:
  -h, --help  show this help message and exit
```

```
$ rlock release --help
usage: rlock release [-h] SIGN_OFF

positional arguments:
  SIGN_OFF    locking or releasing a resource requires signoff

options:
  -h, --help  show this help message and exit
```

@jimdevops19 let me know what you think 