### PR TITLE
limit the output from rlock when waiting for resource

### DIFF
--- a/rlockertools/resourcelocker.py
+++ b/rlockertools/resourcelocker.py
@@ -28,7 +28,7 @@ class ResourceLocker:
             "Authorization": f"Token {self.token}",
         }
 
-    def check_connection(self):
+    def check_connection(self, silent=True):
         """
         Checks Connection to the provided URL after initialization
 
@@ -37,7 +37,8 @@ class ResourceLocker:
         """
         req = requests.get(self.instance_url)
         if req.status_code == 200:
-            print({"CONNECTION": "OK"})
+            if not silent:
+                print({"CONNECTION": "OK"})
             return
         else:
             # Raise Connection Error if no 200
@@ -281,12 +282,17 @@ class ResourceLocker:
                     return queue_to_check
 
                 else:
-                    if queue_status in ["INITIALIZING", "PENDING"]:
+                    if queue_status in ["INITIALIZING"] or (queue_status == "PENDING" and not (attempt % 1000)):
                         print(
                             f"Queue {queue_id} is {queue_status} \n"
                             f"More info about the queue: \n"
                             f"{self.instance_url}/rqueues/{queue_id}"
                         )
+                    elif queue_status in ["PENDING"]:
+                        if (attempt % 50):
+                            print(".", end='', flush=True)
+                        else:
+                            print(".")
                     elif queue_status in ["ABORTED", "FAILED"]:
                         err_msg = (
                             "Queue did NOT finish successfully \n"


### PR DESCRIPTION
The `rlock --lock ...` command prints following four lines during every attempt/check when waiting for a resource, which unnecessary spam the console output.
```
2026-02-17 09:35:16  {'CONNECTION': 'OK'}
2026-02-17 09:35:16  Queue 51748 is PENDING 
2026-02-17 09:35:16  More info about the queue: 
2026-02-17 09:35:16  https://resourcelocker.example.com/rqueues/51748
```

This PR limits the output to something like this:
```
$ rlock --lock --token=*** --resume-on-connection-error --signoff=test-rlock --priority=2 --search-string=testX --server-url=https://resourcelocker.example.com --interval=2 --attempts=100
Waiting until status FINISHED, timeout is set to 200 seconds! 
If the queue is in INITIALIZING state for a while, be sure to check if your queue service is running! 

Queue 51794 is INITIALIZING 
More info about the queue: 
https://resourcelocker.example.com/rqueues/51794
....
....
....
....
...Queue 51794 is PENDING 
More info about the queue: 
https://resourcelocker.example.com/rqueues/51794
....
....
....
....
...Queue 51794 is PENDING 
More info about the queue: 
https://resourcelocker.example.com/rqueues/51794
....
....
....
...Resource Locked Successfully! Info: 

{'data': '{"link": "None", "label": "testX", "signoff": "dahorak-test-rlock", '
         '"username": "ocs4", "final_resource": "test-resource-2"}',
 'description': None,
 'id': 51794,
 'last_beat': '2026-02-17T08:31:06.501642Z',
 'pended_time_descriptive': '9 minutes',
 'pending_time': '584.793999',
 'pending_time_descriptive': '9 minutes',
 'priority': 2,
 'status': 'FINISHED',
 'time_requested': '2026-02-17T08:21:31.515050Z'}
```
This is from testing, the final configuration prints 50 dots per line (one dot per attempt) and the additional info every 1000 attempts. We might decide to change the configuration later, based on how it will be handled by Jenkins job.
Additionally it also hide the unnecessary `{'CONNECTION': 'OK'}` line for every attempt.