### PR TITLE
use shorter interval in the beginning of waiting for resource

### DIFF
--- a/framework/main.py
+++ b/framework/main.py
@@ -69,7 +69,7 @@ def init_argparser():
     parser.add_argument(
         "--interval",
         help="Use this when lock=True, how many seconds to wait between each call"
-        " while checking for a free resource",
+        " while checking for a free resource (this is the maximum time)",
         type=int,
         action="store",
     )


### PR DESCRIPTION
The aim of this change is to be able to extend the check interval when waiting for resource, but didn't wait too long if the resource is available right away. For that reason, we will check the status each 20 seconds for first two minutes and then we will continue with the number of checks and interval based on configuration from command line.