### PR TITLE
1) Add retry logic with exponential backoff for GET requests

### DIFF
--- a/rlockertools/resourcelocker.py
+++ b/rlockertools/resourcelocker.py
@@ -9,9 +9,11 @@ import pprint as pp
 
 
 class ResourceLocker:
-    def __init__(self, instance_url, token):
+    def __init__(self, instance_url, token, max_retries=3, retry_delay=1):
         self.instance_url = instance_url
         self.token = token
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
 
         self.check_connection()
 
@@ -28,6 +30,35 @@ class ResourceLocker:
             "Authorization": f"Token {self.token}",
         }
 
+    def _get_with_retry(self, url, headers=None, timeout=None):
+        """
+        Wrapper for requests.get with retry logic for non-200 status codes
+
+        :param url: URL to make GET request to
+        :param headers: Optional headers dictionary
+        :param timeout: Optional timeout value
+        :return: requests.Response object
+        """
+        last_response = None
+        for attempt in range(self.max_retries):
+            try:
+                response = requests.get(url, headers=headers, timeout=timeout)
+                if response.status_code == 200:
+                    return response
+                last_response = response
+                if attempt < self.max_retries - 1:
+                    delay = self.retry_delay * (2 ** attempt)  # Exponential backoff
+                    print(f"Request to {url} returned status {response.status_code}, retrying in {delay}s... (attempt {attempt + 1}/{self.max_retries})")
+                    time.sleep(delay)
+            except (ConnectionError, ReadTimeout) as e:
+                if attempt < self.max_retries - 1:
+                    delay = self.retry_delay * (2 ** attempt)
+                    print(f"Connection error to {url}, retrying in {delay}s... (attempt {attempt + 1}/{self.max_retries})")
+                    time.sleep(delay)
+                else:
+                    raise
+        return last_response
+
     def check_connection(self, silent=True):
         """
         Checks Connection to the provided URL after initialization
@@ -35,7 +66,7 @@ class ResourceLocker:
         :return: None
         :raises: Connection Error
         """
-        req = requests.get(self.instance_url)
+        req = self._get_with_retry(self.instance_url)
         if req.status_code == 200:
             if not silent:
                 print({"CONNECTION": "OK"})
@@ -116,7 +147,7 @@ class ResourceLocker:
         Display all the resources
         :return: Response in Dictionary
         """
-        req = requests.get(self.endpoints["resources"], headers=self.headers)
+        req = self._get_with_retry(self.endpoints["resources"], headers=self.headers)
         if req.status_code == 200:
             # json.loads returns it to a dictionary:
             req_dict = json.loads(req.text.encode("utf8"))
@@ -143,7 +174,7 @@ class ResourceLocker:
         :return: req
         """
         final_endpoint = self.endpoints["rqueue"] + str(queue_id)
-        req = requests.get(final_endpoint, headers=self.headers)
+        req = self._get_with_retry(final_endpoint, headers=self.headers)
         if req.status_code == 200:
             data_json = json.dumps(
                 {
@@ -168,7 +199,7 @@ class ResourceLocker:
         :return: req
         """
         final_endpoint = self.endpoints["rqueue"] + str(queue_id)
-        req = requests.get(final_endpoint, headers=self.headers)
+        req = self._get_with_retry(final_endpoint, headers=self.headers)
         if req.status_code == 200:
             # Check for data dictionary args to override if needed:
             data_section = parse_queue_data(req.json().get('data'))
@@ -202,7 +233,7 @@ class ResourceLocker:
             if status
             else self.endpoints["rqueues"]
         )
-        req = requests.get(final_endpoint, headers=self.headers)
+        req = self._get_with_retry(final_endpoint, headers=self.headers)
         if req.status_code == 200:
             # json.loads returns it to a dictionary
             req_dict = json.loads(req.text.encode("utf8"))
@@ -219,7 +250,7 @@ class ResourceLocker:
         if verify_connection:
             self.check_connection()
         final_endpoint = self.endpoints["rqueue"] + str(queue_id)
-        req = requests.get(final_endpoint, headers=self.headers)
+        req = self._get_with_retry(final_endpoint, headers=self.headers)
         if req.status_code == 200:
             return req.json()
         else:
@@ -381,7 +412,7 @@ class ResourceLocker:
         else:
             final_endpoint = self.endpoints["resources"] + f"?signoff={signoff}"
 
-        req = requests.get(final_endpoint, headers=self.headers)
+        req = self._get_with_retry(final_endpoint, headers=self.headers)
         if req.status_code == 200:
             # json.loads returns it to a dictionary
             req_dict = json.loads(req.text.encode("utf8"))
@@ -420,7 +451,7 @@ class ResourceLocker:
         :return:
         '''
         final_endpoint = self.endpoints["rqueue"] + str(queue_id)
-        req = requests.get(final_endpoint, headers=self.headers)
+        req = self._get_with_retry(final_endpoint, headers=self.headers)
         if req.status_code == 200:
 
             data = {


### PR DESCRIPTION
Implements configurable retry mechanism for all requests.get() calls to handle transient network failures and non-200 status codes. Adds max_retries and retry_delay parameters to ResourceLocker initialization with exponential backoff strategy.