### PR TITLE
2) Use logging instead of print

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,47 @@ rlock --lock --server-url=your.rlocker.instance.com --token=YOURTOKEN --search-s
 ```bash
 rlock --release --server-url=your.rlocker.instance.com --token=YOURTOKEN --signoff=YOURUNIQUESIGNOFF
 ```
+
+## Logging Configuration
+
+The rlockertools library uses Python's standard logging module. By default, logging is disabled (NullHandler). To enable logging output, configure it in your application:
+
+### Basic Configuration
+
+```python
+import logging
+
+# Configure logging at the start of your application
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+```
+
+### Advanced Configuration
+
+```python
+import logging
+
+# Create a logger for rlockertools
+logger = logging.getLogger('rlockertools')
+logger.setLevel(logging.DEBUG)
+
+# Create console handler with a higher log level
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+
+# Create formatter and add it to the handler
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+
+# Add the handler to the logger
+logger.addHandler(ch)
+```
+
+### Log Levels
+
+- `DEBUG`: Detailed information, typically for diagnosing problems (includes API responses)
+- `INFO`: General informational messages (connection status, resource operations)
+- `WARNING`: Warning messages (retries, timeouts)
+- `ERROR`: Error messages (failures, connection errors)

--- a/framework/main.py
+++ b/framework/main.py
@@ -3,11 +3,19 @@ import os
 import signal
 import pprint as pp
 import time
+import logging
 from urllib.parse import quote
 from requests.exceptions import ConnectionError
 from argparse import ArgumentParser
 from rlockertools.resourcelocker import ResourceLocker
 import sys
+
+# Configure logging for the rlockertools library
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
 
 
 def init_argparser():
@@ -43,8 +51,10 @@ def init_argparser():
         "--check", help="Use this to check if a resource is available", action="store_true"
     )
     parser.add_argument(
-        "--resume-on-connection-error", help="Use this argument in case you don't want to break queue execution"
-                                             " in the middle of waiting for queue status being FINISHED", action="store_true"
+        "--resume-on-connection-error", help=(
+            "Use this argument in case you don't want to break queue execution"
+            " in the middle of waiting for queue status being FINISHED"
+        ), action="store_true"
     )
     parser.add_argument(
         "--signoff",
@@ -154,7 +164,7 @@ def run(args):
                 print(f"by name: {json.dumps(resources_by_name)}")
                 print(f"by label: {json.dumps(resources_by_label)}")
             else:
-                print(f"No resource available.")
+                print("No resource available.")
                 sys.exit(3)
 
     except (ConnectionError) as e:
@@ -171,9 +181,10 @@ def run(args):
             print("You chose to NOT continue on connection errors. \n"
                   "To prevent this, you can run next time with --resume-on-connection-error! \n"
                   "Exiting ... ")
-    except Exception as e:
+    except Exception:
         print("An unexpected error occured!")
         raise
+
 
 def main():
     os.environ["PYTHONUNBUFFERED"] = "1"

--- a/rlockertools/__init__.py
+++ b/rlockertools/__init__.py
@@ -1,3 +1,12 @@
+import logging
+
+# Set up module-level logger
+logger = logging.getLogger(__name__)
+
+# Add a NullHandler to avoid "No handler found" warnings when the library is used
+# Users can configure their own handlers as needed
+logger.addHandler(logging.NullHandler())
+
 __all__ = [
     "resourcelocker",
     "exceptions",

--- a/rlockertools/resourcelocker.py
+++ b/rlockertools/resourcelocker.py
@@ -9,9 +9,11 @@ import pprint as pp
 
 
 class ResourceLocker:
-    def __init__(self, instance_url, token):
+    def __init__(self, instance_url, token, max_retries=3, retry_delay=1):
         self.instance_url = instance_url
         self.token = token
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
 
         self.check_connection()
 
@@ -28,6 +30,35 @@ class ResourceLocker:
             "Authorization": f"Token {self.token}",
         }
 
+    def _get_with_retry(self, url, headers=None, timeout=None):
+        """
+        Wrapper for requests.get with retry logic for non-200 status codes
+
+        :param url: URL to make GET request to
+        :param headers: Optional headers dictionary
+        :param timeout: Optional timeout value
+        :return: requests.Response object
+        """
+        last_response = None
+        for attempt in range(self.max_retries):
+            try:
+                response = requests.get(url, headers=headers, timeout=timeout)
+                if response.status_code == 200:
+                    return response
+                last_response = response
+                if attempt < self.max_retries - 1:
+                    delay = self.retry_delay * (2 ** attempt)  # Exponential backoff
+                    print(f"Request to {url} returned status {response.status_code}, retrying in {delay}s... (attempt {attempt + 1}/{self.max_retries})")
+                    time.sleep(delay)
+            except (ConnectionError, ReadTimeout) as e:
+                if attempt < self.max_retries - 1:
+                    delay = self.retry_delay * (2 ** attempt)
+                    print(f"Connection error to {url}, retrying in {delay}s... (attempt {attempt + 1}/{self.max_retries})")
+                    time.sleep(delay)
+                else:
+                    raise
+        return last_response
+
     def check_connection(self, silent=True):
         """
         Checks Connection to the provided URL after initialization
@@ -35,7 +66,7 @@ class ResourceLocker:
         :return: None
         :raises: Connection Error
         """
-        req = requests.get(self.instance_url)
+        req = self._get_with_retry(self.instance_url)
         if req.status_code == 200:
             if not silent:
                 print({"CONNECTION": "OK"})
@@ -116,7 +147,7 @@ class ResourceLocker:
         Display all the resources
         :return: Response in Dictionary
         """
-        req = requests.get(self.endpoints["resources"], headers=self.headers)
+        req = self._get_with_retry(self.endpoints["resources"], headers=self.headers)
         if req.status_code == 200:
             # json.loads returns it to a dictionary:
             req_dict = json.loads(req.text.encode("utf8"))
@@ -143,7 +174,7 @@ class ResourceLocker:
         :return: req
         """
         final_endpoint = self.endpoints["rqueue"] + str(queue_id)
-        req = requests.get(final_endpoint, headers=self.headers)
+        req = self._get_with_retry(final_endpoint, headers=self.headers)
         if req.status_code == 200:
             data_json = json.dumps(
                 {
@@ -168,7 +199,7 @@ class ResourceLocker:
         :return: req
         """
         final_endpoint = self.endpoints["rqueue"] + str(queue_id)
-        req = requests.get(final_endpoint, headers=self.headers)
+        req = self._get_with_retry(final_endpoint, headers=self.headers)
         if req.status_code == 200:
             # Check for data dictionary args to override if needed:
             data_section = parse_queue_data(req.json().get('data'))
@@ -202,7 +233,7 @@ class ResourceLocker:
             if status
             else self.endpoints["rqueues"]
         )
-        req = requests.get(final_endpoint, headers=self.headers)
+        req = self._get_with_retry(final_endpoint, headers=self.headers)
         if req.status_code == 200:
             # json.loads returns it to a dictionary
             req_dict = json.loads(req.text.encode("utf8"))
@@ -219,7 +250,7 @@ class ResourceLocker:
         if verify_connection:
             self.check_connection()
         final_endpoint = self.endpoints["rqueue"] + str(queue_id)
-        req = requests.get(final_endpoint, headers=self.headers)
+        req = self._get_with_retry(final_endpoint, headers=self.headers)
         if req.status_code == 200:
             return req.json()
         else:
@@ -381,7 +412,7 @@ class ResourceLocker:
         else:
             final_endpoint = self.endpoints["resources"] + f"?signoff={signoff}"
 
-        req = requests.get(final_endpoint, headers=self.headers)
+        req = self._get_with_retry(final_endpoint, headers=self.headers)
         if req.status_code == 200:
             # json.loads returns it to a dictionary
             req_dict = json.loads(req.text.encode("utf8"))
@@ -420,7 +451,7 @@ class ResourceLocker:
         :return:
         '''
         final_endpoint = self.endpoints["rqueue"] + str(queue_id)
-        req = requests.get(final_endpoint, headers=self.headers)
+        req = self._get_with_retry(final_endpoint, headers=self.headers)
         if req.status_code == 200:
 
             data = {

--- a/rlockertools/resourcelocker.py
+++ b/rlockertools/resourcelocker.py
@@ -5,7 +5,10 @@ import requests
 import datetime
 import json
 import time
-import pprint as pp
+import pprint
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class ResourceLocker:
@@ -48,12 +51,18 @@ class ResourceLocker:
                 last_response = response
                 if attempt < self.max_retries - 1:
                     delay = self.retry_delay * (2 ** attempt)  # Exponential backoff
-                    print(f"Request to {url} returned status {response.status_code}, retrying in {delay}s... (attempt {attempt + 1}/{self.max_retries})")
+                    logger.warning(
+                        f"Request to {url} returned status {response.status_code}, "
+                        "retrying in {delay}s... (attempt {attempt + 1}/{self.max_retries})"
+                    )
                     time.sleep(delay)
-            except (ConnectionError, ReadTimeout) as e:
+            except (ConnectionError, ReadTimeout):
                 if attempt < self.max_retries - 1:
                     delay = self.retry_delay * (2 ** attempt)
-                    print(f"Connection error to {url}, retrying in {delay}s... (attempt {attempt + 1}/{self.max_retries})")
+                    logger.warning(
+                        f"Connection error to {url}, retrying in {delay}s... "
+                        "(attempt {attempt + 1}/{self.max_retries})"
+                    )
                     time.sleep(delay)
                 else:
                     raise
@@ -69,7 +78,7 @@ class ResourceLocker:
         req = self._get_with_retry(self.instance_url)
         if req.status_code == 200:
             if not silent:
-                print({"CONNECTION": "OK"})
+                logger.info({"CONNECTION": "OK"})
             return
         else:
             # Raise Connection Error if no 200
@@ -136,10 +145,10 @@ class ResourceLocker:
 
         req = requests.put(final_endpoint, headers=self.headers, data=newjson)
         if req.status_code == 200:
-            print(f"Released {resource['name']} successfully!")
+            logger.info(f"Released {resource['name']} successfully!")
             return req
         else:
-            print(f"There were some errors from the Resource Locker server:")
+            logger.error("There were some errors from the Resource Locker server:")
             prettify_output(req.text)
 
     def all(self):
@@ -184,11 +193,11 @@ class ResourceLocker:
             )
 
             req = requests.put(final_endpoint, headers=self.headers, data=data_json)
-            pp.pprint(req.json())
+            logger.debug(pprint.pformat(req.json()))
             return req
 
-        print(f"Something went wrong aborting the {queue_id} \n")
-        pp.pprint(req.json())
+        logger.error(f"Something went wrong aborting the {queue_id}")
+        logger.debug(pprint.pformat(req.json()))
         return req
 
     def change_queue(self, queue_id, status, description=None, **datakwargs):
@@ -207,7 +216,7 @@ class ResourceLocker:
                 for k, v in datakwargs.items():
                     data_section[k] = v
 
-            print(f"DATA SECTION: {data_section}")
+            logger.debug(f"DATA SECTION: {data_section}")
             # Modify status
             to_modify = {"status": status}
 
@@ -220,11 +229,11 @@ class ResourceLocker:
 
             data_json = json.dumps(to_modify)
             req = requests.put(final_endpoint, headers=self.headers, data=data_json)
-            pp.pprint(req.json())
+            logger.debug(pprint.pformat(req.json()))
             return req
 
-        print(f"Something went wrong changing {queue_id} \n")
-        pp.pprint(req.json())
+        logger.error(f"Something went wrong changing {queue_id} \n")
+        logger.debug(pprint.pformat(req.json()))
         return req
 
     def get_queues(self, status=None):
@@ -254,7 +263,7 @@ class ResourceLocker:
         if req.status_code == 200:
             return req.json()
         else:
-            print(
+            logger.error(
                 f"The request for the queue returned code: {req.status_code} \n"
                 "Response was: \n"
                 f"{req.text}"
@@ -289,7 +298,7 @@ class ResourceLocker:
         """
         expected_status = "FINISHED"
         total_timeout_description = f"cca {attempts * interval} seconds"
-        print(
+        logger.info(
             f"Waiting until status {expected_status}, timeout is set to {total_timeout_description}! \n"
             "If the queue is in INITIALIZING state for a while, "
             "be sure to check if your queue service is running! \n"
@@ -314,26 +323,26 @@ class ResourceLocker:
 
                 else:
                     if queue_status in ["INITIALIZING"] or (queue_status == "PENDING" and not (attempt % 1000)):
-                        print(
+                        logger.info(
                             f"Queue {queue_id} is {queue_status} \n"
                             f"More info about the queue: \n"
                             f"{self.instance_url}/rqueues/{queue_id}"
                         )
                     elif queue_status in ["PENDING"]:
                         if (attempt % 50):
-                            print(".", end='', flush=True)
+                            logger.debug(".")
                         else:
-                            print(".")
+                            logger.debug(".")
                     elif queue_status in ["ABORTED", "FAILED"]:
                         err_msg = (
                             "Queue did NOT finish successfully \n"
                             f"Error is: \n {queue_to_check}"
                         )
                         if silent:
-                            print(
-                                err_msg,
+                            logger.warning(
+                                err_msg +
                                 "Timeout reached, "
-                                "silent=true provided so no exception is raised",
+                                "silent=true provided so no exception is raised"
                             )
                             return None
                         else:
@@ -347,7 +356,7 @@ class ResourceLocker:
                     else:
                         time.sleep(interval)
             except ConnectionError as e:
-                print(
+                logger.error(
                     "Connection Error to the specified URL! \n"
                     "Error is: \n"
                     f"{str(e)}"
@@ -359,24 +368,24 @@ class ResourceLocker:
                     # We want to continuously show this message, in order to avoid iteration, and waste the attempts
                     # on connection errors.
                     while True:
-                        print(
-                            f"Will try again in {interval} seconds \n"
-                            "NOTE: Timeout duration is paused! \n"
+                        logger.info(
+                            f"Will try again in {interval} seconds. NOTE: Timeout duration is paused! "
                             "You decided to wait if connection errors will occur, your queue "
-                            f"will still have a timeout of {(attempts - attempt) * interval} seconds, once the resource locker server is back!"
+                            f"will still have a timeout of {(attempts - attempt) * interval} seconds,"
+                            "once the resource locker server is back!"
                         )
                         time.sleep(interval)
                         try:
                             self.check_connection()
                             # If method did not raise, get out, server is up
                             break
-                        except:
+                        except Exception:
                             pass
                 else:
                     raise
             except Exception as e:
-                print("An unknown exception occured: \n"
-                      f"{str(e)}")
+                logger.error("An unknown exception occured: \n"
+                             f"{str(e)}")
                 raise
 
         else:
@@ -389,7 +398,7 @@ class ResourceLocker:
                     f"Time Waited: {attempts * interval} seconds",
                 )
             if silent:
-                print("Timeout reached, silent=true provided so no exception is raised")
+                logger.warning("Timeout reached, silent=true provided so no exception is raised")
                 return None
             else:
                 raise Exception(
@@ -462,9 +471,9 @@ class ResourceLocker:
 
             req = requests.put(final_endpoint, headers=self.headers, data=data_json)
             if not suppress_logs:
-                pp.pprint(req.json())
+                logger.debug(pprint.pformat(req.json()))
             return req
 
-        print(f"Something went wrong beating {queue_id} \n")
-        pp.pprint(req.text)
+        logger.error(f"Something went wrong beating {queue_id}")
+        logger.debug(pprint.pformat(req.text))
         return req

--- a/rlockertools/utils.py
+++ b/rlockertools/utils.py
@@ -1,5 +1,8 @@
-import pprint as pp
+import logging
+import pprint
 import json
+
+logger = logging.getLogger(__name__)
 
 
 def prettify_output(text):
@@ -9,9 +12,10 @@ def prettify_output(text):
     :return:
     """
     try:
-        pp.pprint(json.loads(text.encode("utf8")))
-    except:
-        print(text)
+        logger.info(pprint.pformat(json.loads(text.encode("utf8"))))
+    except Exception:
+        logger.info(text)
+
 
 def parse_queue_data(data_section):
     """


### PR DESCRIPTION
Depends on https://github.com/red-hat-storage/rlockertools/pull/31

Replace print statements with Python logging
    
- Replace all print() calls with appropriate logger methods (info/warning/error/debug)
- Replace pprint.pprint() with logger.debug(pprint.pformat())
- Add logging configuration with NullHandler to rlockertools module
- Configure logging in framework CLI for rlockertools library
- Add comprehensive logging documentation to README
- Apply formatting fixes to exception handling and string formatting